### PR TITLE
removed universe->sources line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:precise
 MAINTAINER Ben Cawkwell <bencawkwell@gmail.com>
 
 # Update the system
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get upgrade -y
 


### PR DESCRIPTION
The default ubuntu docker image has moved on to trusty since this file was created, so including this line causes the docker image build to fail.

Since universe is now included in the default docker ubuntu image, I don't think this line is still needed.
